### PR TITLE
Fix to modSize read

### DIFF
--- a/ksparser.py
+++ b/ksparser.py
@@ -174,7 +174,11 @@ class part:
             if line.split()[0] == "modMass":
                 self.modMass = float(line.split()[2])                           #"modMass = 0" -> _______________? (always 0)
             if line.split()[0] == "modSize":                                    #(line below this one) "modSize = (0.0, 0.0, 0.0)" -> (0.0, 0.0, 0.0), y<>z
-                self.modSize = tuple([float(" ".join(line.split()[2:]).split(", ")[0][1:]), float(" ".join(line.split()[2:]).split(", ")[2][0:-1]), float(" ".join(line.split()[2:]).split(", ")[1])])
+                #self.modSize = tuple([float(" ".join(line.split()[2:]).split(", ")[0][1:]), float(" ".join(line.split()[2:]).split(", ")[2][0:-1]), float(" ".join(line.split()[2:]).split(", ")[1])])
+                ####---STH 2017.0111
+                #looks like the file format changed?
+                #modSize = 0,0,0
+                self.modSize = zup_tuple(line)
             if line.split()[0] == "link":
                 self.linklist.append(link(line))                                #new entry in list of links with new link instance
             if line.split()[0] == "attN":


### PR DESCRIPTION
Did the KSP file format change? Seems like modSize was a tuple of
floats and is now a tuple of ints? Minor change to the code, anyway.

Corresponds to something reported on the forum.